### PR TITLE
Fixes npx trying to install `json` globally and failing

### DIFF
--- a/scripts/scope.sh
+++ b/scripts/scope.sh
@@ -7,7 +7,7 @@ scope() {
     echo "Package name already scoped"
   else
     echo "Package name not scoped"
-    npx json -f package.json -e "this.name=\"@AURIN/${npm_package_name}\""
+    json -I -f package.json -e "this.name=\"@AURIN/${npm_package_name}\""
   fi
 }
 


### PR DESCRIPTION
Replaces `npx json` with just `json` as npm adds `node_modules/.bin/` to script paths by default